### PR TITLE
fix: resize logo in README to appropriate size

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Gocha - Bookmark Manager
 
-![Gocha Logo](./src/assets/drop.svg)
+<p align="center">
+  <img src="./src/assets/drop.svg" alt="Gocha Logo" width="120" height="120">
+</p>
 
 _A modern and minimalist application for managing your favourite bookmarks_
 


### PR DESCRIPTION
- Change from Markdown image to HTML img tag with size controls
- Set logo dimensions to 120x120px for better readability
- Centre the logo for better visual presentation