### PR TITLE
build: :lock: patch postcss vulnerability using pnpm overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "overrides": {
       "js-yaml": "^4.1.1",
       "picomatch": "^4.0.4",
-      "brace-expansion": "^5.0.6"
+      "brace-expansion": "^5.0.6",
+      "postcss": "^8.5.15"
     },
     "ignoredBuiltDependencies": [
       "@parcel/watcher"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,7 @@ overrides:
   js-yaml: ^4.1.1
   picomatch: ^4.0.4
   brace-expansion: ^5.0.6
+  postcss: ^8.5.15
 
 importers:
 
@@ -1114,8 +1115,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.11:
-    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+  nanoid@3.3.12:
+    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -1198,8 +1199,8 @@ packages:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
 
-  postcss@8.5.8:
-    resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
+  postcss@8.5.15:
+    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
     engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
@@ -2600,7 +2601,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.11: {}
+  nanoid@3.3.12: {}
 
   natural-compare@1.4.0: {}
 
@@ -2687,9 +2688,9 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss@8.5.8:
+  postcss@8.5.15:
     dependencies:
-      nanoid: 3.3.11
+      nanoid: 3.3.12
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -2990,7 +2991,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.5.8
+      postcss: 8.5.15
       rolldown: 1.0.0-rc.13
       tinyglobby: 0.2.15
     optionalDependencies:


### PR DESCRIPTION
Resolved a Moderate security vulnerability identified in the postcss 
package (a transitive dependency via vite) by utilising pnpm overrides:

1. PostCSS (XSS via Unescaped </style> in CSS Stringify Output):
   - Mitigated a Cross-Site Scripting (XSS) flaw where the CSS stringifier 
     did not properly escape </style> tags, potentially allowing arbitrary 
     JavaScript execution if the output is inserted into the DOM.
   - Enforced resolution to ^8.5.10 to ensure secure output parsing.

Changes:
- Added 'postcss' to the "pnpm.overrides" configuration.
- Regenerated pnpm-lock.yaml.